### PR TITLE
Add root-level Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ The API will be available on `http://localhost:8000`.
 
 ## Frontend
 
-The frontend is a React app bootstrapped with Vite. Install dependencies and start the dev server:
+The frontend is a React app bootstrapped with Vite. Install dependencies and
+start the dev server from the repository root:
 
 ```bash
-cd frontend
 npm install
 npm run dev
 ```
 
-The frontend will be served at `http://localhost:5173`.
+Vite will serve files from `http://localhost:5173/` using the configuration in
+`vite.config.js`.
 
 ## Directory Structure
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  root: "frontend",
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add `vite.config.js` to configure Vite to run from repo root
- include `@vitejs/plugin-react` as a dev dependency
- update README with new instructions and mention served URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68533d362a80832db99d0d759dc63f49