### PR TITLE
Fix uploaded filename usage

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
 import sqlite3
 from pathlib import Path
+from datetime import datetime
 
 DB_PATH = Path(__file__).parent / "db.sqlite3"
 UPLOAD_DIR = Path(__file__).parent / "uploads"
@@ -35,7 +36,12 @@ def create_post(title: str, description: str = "", category: str = "",
                 photo: UploadFile = File(None)):
     photo_path = None
     if photo:
-        photo_path = UPLOAD_DIR / photo.filename
+        # Strip any path components from the uploaded filename
+        filename = Path(photo.filename).name
+        # Prefix the filename with a timestamp to avoid collisions
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
+        filename = f"{timestamp}_{filename}"
+        photo_path = UPLOAD_DIR / filename
         with photo_path.open("wb") as f:
             f.write(photo.file.read())
     conn = get_db()


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames using `Path(photo.filename).name`
- prefix filenames with timestamp to avoid collisions

## Testing
- `python -m py_compile backend/app.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68535327ebe8832dbc3720ed502dae90