### PR TITLE
Ignore uploads directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ venv/
 __pycache__/
 frontend/node_modules/
 backend/db.sqlite3
+
+backend/uploads/


### PR DESCRIPTION
## Summary
- ignore `backend/uploads/` to prevent uploaded files from being committed

## Testing
- `python -m py_compile backend/app.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_685353242ddc832db9def0aefd3b4005