### PR TITLE
Add CORS middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ python main.py
 
 The API will be available on `http://localhost:8000`.
 
+CORS is enabled for the development frontend at `http://localhost:5173`, so the React app can make requests to the API during local development.
+
 ## Frontend
 
 The frontend is a React app bootstrapped with Vite. Install dependencies and start the dev server:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 import sqlite3
 from pathlib import Path
 
@@ -8,6 +9,14 @@ UPLOAD_DIR = Path(__file__).parent / "uploads"
 UPLOAD_DIR.mkdir(exist_ok=True)
 
 app = FastAPI(title="SpotMap Prototype")
+
+# Allow requests from the React dev server
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- add CORS middleware to backend app
- enable origin from the React dev server
- mention CORS configuration in the docs

## Testing
- `python -m py_compile backend/app.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685353222590832db3a86c31380bed7c