### PR TITLE
Enable CORS for local frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ python main.py
 
 The API will be available on `http://localhost:8000`.
 
+Cross-origin requests from `http://localhost:5173` are allowed by default so
+the frontend dev server can communicate with the API.
+
 ## Frontend
 
 The frontend is a React app bootstrapped with Vite. Install dependencies and start the dev server:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 import sqlite3
 from pathlib import Path
 
@@ -8,6 +9,15 @@ UPLOAD_DIR = Path(__file__).parent / "uploads"
 UPLOAD_DIR.mkdir(exist_ok=True)
 
 app = FastAPI(title="SpotMap Prototype")
+
+# Allow requests from the Vite dev server
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- allow cross-origin requests from the Vite dev server
- document the CORS setting in the backend setup instructions

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685356f1eebc832daedabb85fda75327