### PR TITLE
Sanitize uploaded filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a local-first prototype with a Python backend and a Rea
 
 ## Backend
 
-The backend uses FastAPI with a SQLite database. Posts and uploaded photos are stored locally.
+The backend uses FastAPI with a SQLite database. Posts and uploaded photos are stored locally. Uploaded filenames are sanitized and given a random prefix before saving to prevent collisions and unsafe paths.
 
 Run the backend:
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
 import sqlite3
 from pathlib import Path
+from uuid import uuid4
 
 DB_PATH = Path(__file__).parent / "db.sqlite3"
 UPLOAD_DIR = Path(__file__).parent / "uploads"
@@ -35,7 +36,11 @@ def create_post(title: str, description: str = "", category: str = "",
                 photo: UploadFile = File(None)):
     photo_path = None
     if photo:
-        photo_path = UPLOAD_DIR / photo.filename
+        # Sanitize filename and add a random prefix to avoid path
+        # traversal issues and collisions
+        filename = Path(photo.filename).name
+        randomized = f"{uuid4().hex}_{filename}"
+        photo_path = UPLOAD_DIR / randomized
         with photo_path.open("wb") as f:
             f.write(photo.file.read())
     conn = get_db()


### PR DESCRIPTION
## Summary
- sanitize and randomize uploaded photo filename in `create_post`
- document filename handling in README

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685356ef61bc832db27c06db3a6ee121