### PR TITLE
Ignore backend uploads files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ frontend/node_modules/
 frontend/dist/
 backend/db.sqlite3
 
-backend/uploads/
+backend/uploads/*
+!backend/uploads/.gitkeep
 *.pyc


### PR DESCRIPTION
## Summary
- ignore all uploaded files while keeping the directory
- retain `backend/uploads/.gitkeep` so the folder remains in the repo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68535eeebb20832d867b83ef3db3818e