### PR TITLE
Add sample CSV data and document location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains a local-first prototype with a Python backend and a Rea
 
 The backend uses FastAPI with a SQLite database. Posts and uploaded photos are stored locally.
 
+### CSV Data
+
+Any CSV files used for prototyping or testing can be placed in `backend/data`. Two tiny sample files, `crime.csv` and `offenders.csv`, are provided in that directory.
+
 Run the backend:
 
 ```bash

--- a/backend/data/crime.csv
+++ b/backend/data/crime.csv
@@ -1,0 +1,3 @@
+id,description,latitude,longitude
+1,Burglary,34.05,-118.24
+2,Robbery,40.71,-74.00

--- a/backend/data/offenders.csv
+++ b/backend/data/offenders.csv
@@ -1,0 +1,3 @@
+id,name,crime_id
+1,John Doe,1
+2,Jane Smith,2


### PR DESCRIPTION
## Summary
- provide tiny `crime.csv` and `offenders.csv` examples
- document the `backend/data` directory for CSV files in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68535ef39934832d9125e1cc6188080c