### PR TITLE
Add httpx to dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ frontend/
 
 ## Running Tests
 
-Install the development dependencies and run `pytest`:
+Install the development dependencies and run `pytest`. The dev requirements
+include `httpx`, which is needed by FastAPI's `TestClient` used in the tests:
 
 ```bash
 python -m venv venv && source venv/bin/activate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest
+
+httpx


### PR DESCRIPTION
## Summary
- document that httpx is required for tests
- add httpx to requirements-dev.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685361507dfc832db079e2f49fa1771e